### PR TITLE
feat(czctl): auto-bump brew formula based on release.json

### DIFF
--- a/Formula/czctl.rb
+++ b/Formula/czctl.rb
@@ -1,10 +1,13 @@
+require 'open-uri'
+
 class Czctl < Formula
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
   os = OS.mac? ? "darwin" : "linux"
+  releases = JSON.load(open("https://releases.codezero.io/release.json"))
 
   desc "Develop, debug, deploy using CodeZero"
   homepage "https://codezero.io/"
-  version "1.4.0"
+  version releases["stable"]["version"]
   
   url "https://releases.codezero.io/#{version}/headless-#{os}-#{arch}.tgz"
 


### PR DESCRIPTION
## Description

Homebrew installation can pull from https://releases.codezero.io/release.json to determine the current stable version.

fixes https://github.com/c6o/node-monorepo/issues/2645